### PR TITLE
Fixed race condition where g_drm_device_type would end up getting set to...

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapidisplay_drm.c
+++ b/gst-libs/gst/vaapi/gstvaapidisplay_drm.c
@@ -382,6 +382,7 @@ gst_vaapi_display_drm_new (const gchar * device_path)
   GstVaapiDisplay *display;
   guint types[2], i, num_types = 0;
 
+  g_mutex_lock (&g_drm_device_type_lock);
   if (device_path)
     types[num_types++] = 0;
   else if (g_drm_device_type)
@@ -391,7 +392,6 @@ gst_vaapi_display_drm_new (const gchar * device_path)
     types[num_types++] = DRM_DEVICE_LEGACY;
   }
 
-  g_mutex_lock (&g_drm_device_type_lock);
   for (i = 0; i < num_types; i++) {
     g_drm_device_type = types[i];
     display = gst_vaapi_display_new (gst_vaapi_display_drm_class (),


### PR DESCRIPTION
There is a race condition where g_drm_device_type can be left set to DRM_DEVICE_RENDERNODES when it shouldn't.

If thread 1 comes in and falls into the last else statement setting up both RENDERNODES and LEGACY types. And begins to process the first type (RENDERNODES), it sets g_drm_device_type = RENDERNODES.

Now when thread 2 comes in and sees g_drm_device_type is RENDERNODES, it queues up that type to be tried but then encounters the lock and has to wait until the first thread finishes. Once the lock is acquired it will then proceed to ONLY try RENDERNODES and fail it. But it doesn't try LEGACY. And from then on, all future attempts will only try RENDERNODES.

So to avoid this situation I have simply moved the acquisition of the lock higher up.