### PR TITLE
Update vaapidecode to use cropped width and height in caps

### DIFF
--- a/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
@@ -1521,8 +1521,8 @@ ensure_context(GstVaapiDecoderH264 *decoder, GstH264SPS *sps)
     info.profile    = priv->profile;
     info.entrypoint = priv->entrypoint;
     info.chroma_type = priv->chroma_type;
-    info.width      = sps->width;
-    info.height     = sps->height;
+    info.width      = sps->crop_rect_width;
+    info.height     = sps->crop_rect_height;
     info.ref_frames = dpb_size;
 
     if (!gst_vaapi_decoder_ensure_context(GST_VAAPI_DECODER(decoder), &info))

--- a/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
+++ b/gst-libs/gst/vaapi/gstvaapidecoder_h264.c
@@ -1517,7 +1517,6 @@ ensure_context(GstVaapiDecoderH264 *decoder, GstH264SPS *sps)
     if (!reset_context && priv->has_context)
         return GST_VAAPI_DECODER_STATUS_SUCCESS;
 
-    /* XXX: fix surface size when cropping is implemented */
     info.profile    = priv->profile;
     info.entrypoint = priv->entrypoint;
     info.chroma_type = priv->chroma_type;


### PR DESCRIPTION
Appears from the comments that this was intended to be done anyway.  We have a 1280x720 stream coming in with width of 1280x736 in the caps without this change.